### PR TITLE
feat: Equal extension handles Actual and Expected values of different types

### DIFF
--- a/src/NExpect.Tests/TestEqualityExtensions.cs
+++ b/src/NExpect.Tests/TestEqualityExtensions.cs
@@ -1567,6 +1567,146 @@ namespace NExpect.Tests
         }
 
         [TestFixture]
+        public class ActingOnMismatchedTypes
+        {
+            [Test]
+            public void Expect_Byte_ToEqual_Int_WhenMatches_ShouldNotThrow()
+            {
+                // Arrange
+                byte actual = 1;
+                int expected = 1;
+                // Pre-Assert
+
+                // Act
+                Assert.That(
+                    () => Expect(actual).To.Equal(expected),
+                    Throws.Nothing
+                );
+                // Assert
+            }
+
+            [Test]
+            public void Expect_Byte_ToEqual_Int_WhenNotMatches_ShouldThrow()
+            {
+                // Arrange
+                byte actual = 1;
+                int expected = 2;
+                // Pre-Assert
+
+                // Act
+                Assert.That(
+                    () => Expect(actual).To.Equal(expected),
+                    Throws.Exception
+                        .InstanceOf<UnmetExpectationException>()
+                        .With.Message.Contains($"Expected {expected} but got {actual}")
+                );
+                // Assert
+            }
+
+            [Test]
+            public void Expect_Short_ToEqual_Long_WhenMatches_ShouldNotThrow()
+            {
+                // Arrange
+                short actual = 1;
+                long expected = 1;
+                // Pre-Assert
+
+                // Act
+                Assert.That(
+                    () => Expect(actual).To.Equal(expected),
+                    Throws.Nothing
+                );
+                // Assert
+            }
+
+            [Test]
+            public void Expect_Short_ToEqual_Long_WhenNotMatches_ShouldThrow()
+            {
+                // Arrange
+                short actual = 1;
+                long expected = 2;
+                // Pre-Assert
+
+                // Act
+                Assert.That(
+                    () => Expect(actual).To.Equal(expected),
+                    Throws.Exception
+                        .InstanceOf<UnmetExpectationException>()
+                        .With.Message.Contains($"Expected {expected} but got {actual}")
+                );
+                // Assert
+            }
+
+            [Test]
+            public void Expect_Int_ToEqual_Long_WhenMatches_ShouldNotThrow()
+            {
+                // Arrange
+                int actual = 1;
+                long expected = 1;
+                // Pre-Assert
+
+                // Act
+                Assert.That(
+                    () => Expect(actual).To.Equal(expected),
+                    Throws.Nothing
+                );
+                // Assert
+            }
+
+            [Test]
+            public void Expect_Int_ToEqual_Long_WhenNotMatches_ShouldThrow()
+            {
+                // Arrange
+                int actual = 1;
+                long expected = 2;
+                // Pre-Assert
+
+                // Act
+                Assert.That(
+                    () => Expect(actual).To.Equal(expected),
+                    Throws.Exception
+                        .InstanceOf<UnmetExpectationException>()
+                        .With.Message.Contains($"Expected {expected} but got {actual}")
+                );
+                // Assert
+            }
+            
+            [Test]
+            public void Expect_Float_ToEqual_Double_WhenMatches_ShouldNotThrow()
+            {
+                // Arrange
+                float actual = 1.1f;
+                double expected = 1.1f;
+                // Pre-Assert
+
+                // Act
+                Assert.That(
+                    () => Expect(actual).To.Equal(expected),
+                    Throws.Nothing
+                );
+                // Assert
+            }
+
+            [Test]
+            public void Expect_Float_ToEqual_Double_WhenNotMatches_ShouldThrow()
+            {
+                // Arrange
+                float actual = 1.1f;
+                double expected = 1.2f;
+                // Pre-Assert
+
+                // Act
+                Assert.That(
+                    () => Expect(actual).To.Equal(expected),
+                    Throws.Exception
+                        .InstanceOf<UnmetExpectationException>()
+                        .With.Message.Contains($"Expected {expected} but got {actual}")
+                );
+                // Assert
+            }
+        }
+
+        [TestFixture]
         public class ReferenceEqualityTesting
         {
             public class Coordinate

--- a/src/NExpect/Expectations.cs
+++ b/src/NExpect/Expectations.cs
@@ -25,6 +25,83 @@ namespace NExpect
         }
 
         /// <summary>
+        /// Starts an expectation with sbyte value and up casts to long. Usually used to
+        /// check for equality.
+        /// </summary>
+        /// <param name="value">SByte value to start with.</param>
+        /// <returns>IExpectation&lt;longT&gt;</returns>
+        public static IExpectation<long> Expect(sbyte value)
+        {
+            return new Expectation<long>(value);
+        }
+
+        /// <summary>
+        /// Starts an expectation with short value and up casts to long. Usually used to
+        /// check for equality.
+        /// </summary>
+        /// <param name="value">Short value to start with.</param>
+        /// <returns>IExpectation&lt;longT&gt;</returns>
+        public static IExpectation<long> Expect(short value)
+        {
+            return new Expectation<long>(value);
+        }
+
+        /// <summary>
+        /// Starts an expectation with integer value and up casts to long. Usually used to
+        /// check for equality.
+        /// </summary>
+        /// <param name="value">Int value to start with.</param>
+        /// <returns>IExpectation&lt;longT&gt;</returns>
+        public static IExpectation<long> Expect(int value)
+        {
+            return new Expectation<long>(value);
+        }
+
+        /// <summary>
+        /// Starts an expectation with byte value and up casts to long. Usually used to
+        /// check for equality.
+        /// </summary>
+        /// <param name="value">Byte value to start with.</param>
+        /// <returns>IExpectation&lt;long&gt;</returns>
+        public static IExpectation<long> Expect(byte value)
+        {
+            return new Expectation<long>(value);
+        }
+
+        /// <summary>
+        /// Starts an expectation with unsigned short value and up casts to long. Usually used to
+        /// check for equality.
+        /// </summary>
+        /// <param name="value">UShort value to start with.</param>
+        /// <returns>IExpectation&lt;long&gt;</returns>
+        public static IExpectation<long> Expect(ushort value)
+        {
+            return new Expectation<long>(value);
+        }
+
+        /// <summary>
+        /// Starts an expectation with unsigned integer value and up casts to long. Usually used to
+        /// check for equality.
+        /// </summary>
+        /// <param name="value">UInt value to start with.</param>
+        /// <returns>IExpectation&lt;long&gt;</returns>
+        public static IExpectation<long> Expect(uint value)
+        {
+            return new Expectation<long>(value);
+        }
+
+        /// <summary>
+        /// Starts an expectation with float value and up casts to double. Usually used to
+        /// check for equality.
+        /// </summary>
+        /// <param name="value">Float value to start with.</param>
+        /// <returns>IExpectation&lt;double&gt;</returns>
+        public static IExpectation<double> Expect(float value)
+        {
+            return new Expectation<double>(value);
+        }
+
+        /// <summary>
         /// Start an expectation with an action. Usually used to check
         /// if said action throws an exception
         /// </summary>


### PR DESCRIPTION
Hey Dav

This is obviously great when you have ints, longs, decimals, and so on, but it also has the side effect of allowing 1(int) and "1"(string) to be matched successfully. I'm not sure if this is a desired effect.

Cheers
Cobus