### PR TITLE
Allow Expect().To.Equal() to be called with null values.

### DIFF
--- a/src/NExpect.Tests/TestCollectionExtensions.cs
+++ b/src/NExpect.Tests/TestCollectionExtensions.cs
@@ -1144,6 +1144,26 @@ namespace NExpect.Tests
                     .With.Message.Contains("] to be null"));
                 // Assert
             }
+
+            [TestFixture]
+            public class WithCustomMessage
+            {
+                [Test]
+                public void OperatingOnNull_Negated_ShouldThrow()
+                {
+                    // Arrange
+                    var expectedMessage = "My Message";
+                    List<string> collection = null;
+                    // Pre-Assert
+                    // Act
+                    Assert.That(() =>
+                    {
+                        Expect(collection).Not.To.Be.Null(expectedMessage);
+                    }, Throws.Exception.InstanceOf<UnmetExpectationException>()
+                        .With.Message.Contains(expectedMessage));
+                    // Assert
+                }
+            }
         }
     }
 }

--- a/src/NExpect.Tests/TestEqualityExtensions.cs
+++ b/src/NExpect.Tests/TestEqualityExtensions.cs
@@ -213,6 +213,62 @@ namespace NExpect.Tests
 
                 // Assert
             }
+            
+            [TestFixture]
+            public class ActingOnNulls
+            {
+                [Test]
+                public void GivenActualIsNull_WhenDoesNotMatch_ShouldThrow_WithValidMessage()
+                {
+                    // Arrange
+                    string actual = null;
+                    string expected = "1";
+                    // Pre-Assert
+
+                    // Act
+                    Assert.That(
+                        () => Expect(actual).To.Equal(expected),
+                        Throws.Exception
+                            .InstanceOf<UnmetExpectationException>()
+                            .With.Message.Contains($"Expected {expected} but got {actual}")
+                    );
+                    // Assert
+                }
+
+                [Test]
+                public void GivenExpectationIsNull_WhenDoesNotMatch_ShouldThrow_WithValidMessage()
+                {
+                    // Arrange
+                    string actual = "1";
+                    string expected = null;
+                    // Pre-Assert
+
+                    // Act
+                    Assert.That(
+                        () => Expect(actual).To.Equal(expected),
+                        Throws.Exception
+                            .InstanceOf<UnmetExpectationException>()
+                            .With.Message.Contains($"Expected {expected} but got {actual}")
+                    );
+                    // Assert
+                }
+
+                [Test]
+                public void GivenActualAndExpectationAreNull_WhenMatches_ShouldNotThrow()
+                {
+                    // Arrange
+                    string actual = null;
+                    string expected = null;
+                    // Pre-Assert
+
+                    // Act
+                    Assert.That(
+                        () => Expect(actual).To.Equal(expected),
+                        Throws.Nothing
+                    );
+                    // Assert
+                }
+            }
         }
 
         public class ToMatch

--- a/src/NExpect/CollectionExtensions.cs
+++ b/src/NExpect/CollectionExtensions.cs
@@ -242,13 +242,22 @@ namespace NExpect
             this ICollectionBe<T> be
         )
         {
+            be.Null(null);
+        }
+
+        public static void Null<T>(
+            this ICollectionBe<T> be,
+            string customMessage
+        )
+        {
             be.AddMatcher(collection =>
             {
                 var passed = collection == null;
                 var not = passed ? "not " : "";
                 return new MatcherResult(
                     passed,
-                    $"Expected {CollectionPrint(collection)} {not}to be null"
+                    FinalMessageFor($"Expected {CollectionPrint(collection)} {not}to be null",
+                    customMessage)
                 );
             });
         }

--- a/src/NExpect/EqualityProviderExtensions.cs
+++ b/src/NExpect/EqualityProviderExtensions.cs
@@ -54,7 +54,7 @@ namespace NExpect
         /// <param name="expected">Expected value</param>
         /// <typeparam name="T">Type of object being tested</typeparam>
         public static void Equal<T>(
-            this ICanAddMatcher<T> continuation, 
+            this ICanAddMatcher<T> continuation,
             T expected
         )
         {
@@ -69,14 +69,15 @@ namespace NExpect
         /// <param name="customMessage">Custom message to include when failing</param>
         /// <typeparam name="T">Type of object being tested</typeparam>
         public static void Equal<T>(
-            this ICanAddMatcher<T> continuation, 
-            T expected, 
+            this ICanAddMatcher<T> continuation,
+            T expected,
             string customMessage
         )
         {
             continuation.AddMatcher(actual =>
             {
-                if (actual.Equals(expected))
+                if (ValuesAreEqual(expected, actual)||
+                    BothAreNull(expected, actual))
                     return new MatcherResult(true, $"Did not expect {expected}, but got exactly that");
                 return new MatcherResult(false,
                     FinalMessageFor(
@@ -84,6 +85,16 @@ namespace NExpect
                         customMessage
                     ));
             });
+        }
+
+        private static bool ValuesAreEqual<T>(T expected, T actual)
+        {
+            return actual != null && (actual.Equals(expected));
+        }
+
+        private static bool BothAreNull<T>(T expected, T actual)
+        {
+            return actual == null && expected == null;
         }
 
         /// <summary>
@@ -195,7 +206,7 @@ namespace NExpect
             this INullOr<string> nullOr
         )
         {
-            nullOr.AddMatcher(actual => 
+            nullOr.AddMatcher(actual =>
             {
                 var passed = string.IsNullOrEmpty(actual);
                 var not = passed ? "not " : "";
@@ -214,7 +225,7 @@ namespace NExpect
             this INullOr<string> nullOr
         )
         {
-            nullOr.AddMatcher(actual => 
+            nullOr.AddMatcher(actual =>
             {
                 var passed = string.IsNullOrWhiteSpace(actual);
                 var not = passed ? "not " : "";


### PR DESCRIPTION
fix: Fail with proper message when Expect().To.Equal() is called with null values
feat: overload for ICollection.To.Be.Null with custom error message