### PR TITLE
String values with quotes in unmet expectation messages

### DIFF
--- a/src/NExpect.Tests/TestEqualityExtensions.cs
+++ b/src/NExpect.Tests/TestEqualityExtensions.cs
@@ -230,7 +230,7 @@ namespace NExpect.Tests
                         () => Expect(actual).To.Equal(expected),
                         Throws.Exception
                             .InstanceOf<UnmetExpectationException>()
-                            .With.Message.Contains($"Expected {expected} but got {actual}")
+                            .With.Message.Contains($"Expected \"{expected}\" but got {actual}")
                     );
                     // Assert
                 }
@@ -248,7 +248,7 @@ namespace NExpect.Tests
                         () => Expect(actual).To.Equal(expected),
                         Throws.Exception
                             .InstanceOf<UnmetExpectationException>()
-                            .With.Message.Contains($"Expected {expected} but got {actual}")
+                            .With.Message.Contains($"Expected (null) but got \"{actual}\"")
                     );
                     // Assert
                 }
@@ -1877,6 +1877,117 @@ namespace NExpect.Tests
                 {
                     Expect(collection).To.Be(other);
                 }, Throws.Exception.InstanceOf<UnmetExpectationException>());
+                // Assert
+            }
+        }
+        
+        [TestFixture]
+        public class UnmetExpectationMessageTesting
+        {
+            [Test]
+            public void GivenStrings_WhenNotMatched_ShouldThrow_WithQuotesAroundValuesInMessage()
+            {
+                // Arrange
+                var actual = GetRandomString();
+                var expected = GetAnother(actual);
+                // Pre-Assert
+                // Act
+                Assert.That(() =>
+                    {
+                        Expect(actual).To.Equal(expected);
+                    },
+                    Throws.Exception.InstanceOf<UnmetExpectationException>()
+                        .With.Message.Contains($"Expected \"{expected}\" but got \"{actual}\"")
+                );
+                // Assert
+            }
+
+            [Test]
+            public void GivenStrings_WhenMatchedAndNegated_ShouldThrow_WithQuotesAroundValuesInMessage()
+            {
+                // Arrange
+                var value = GetRandomString();
+                // Pre-Assert
+                // Act
+                Assert.That(() =>
+                    {
+                        Expect(value).To.Not.Equal(value);
+                    },
+                    Throws.Exception.InstanceOf<UnmetExpectationException>()
+                        .With.Message.Contains($"Did not expect \"{value}\", but got exactly that")
+                );
+                // Assert
+            }
+
+            [Test]
+            public void GivenStringAndNullString_WhenNotMatched_ShouldThrow_WithNullIdentifierInMessage()
+            {
+                // Arrange
+                string actual = null;
+                var expected = GetRandomString();
+                // Pre-Assert
+                // Act
+                Assert.That(() =>
+                    {
+                        Expect(actual).To.Equal(expected);
+                    },
+                    Throws.Exception.InstanceOf<UnmetExpectationException>()
+                        .With.Message.Contains($"Expected \"{expected}\" but got (null)")
+                );
+                // Assert
+            }
+
+            [Test]
+            public void GivenObjectAndNullObject_WhenNotMatched_ShouldThrow_WithNullIdentifierInMessage()
+            {
+                // Arrange
+                object actual = null;
+                var expected = new object();
+                // Pre-Assert
+                // Act
+                Assert.That(() =>
+                    {
+                        Expect(actual).To.Equal(expected);
+                    },
+                    Throws.Exception.InstanceOf<UnmetExpectationException>()
+                        .With.Message.Contains($"Expected {expected} but got (null)")
+                );
+                // Assert
+            }
+
+            [Test]
+            public void GivenInts_WhenNotMatched_ShouldThrow_WithoutQuotesAroundValuesInMessage()
+            {
+                // Arrange
+                var actual = GetRandomInt();
+                var expected = GetAnother(actual);
+                // Pre-Assert
+                // Act
+                Assert.That(() =>
+                    {
+                        Expect(actual).To.Equal(expected);
+                    },
+                    Throws.Exception.InstanceOf<UnmetExpectationException>()
+                        .With.Message.Contains($"Expected {expected} but got {actual}")
+                );
+                // Assert
+            }
+
+            [Test]
+            public void GivenObjects_WhenNotMatched_ShouldThrow_WithoutQuotesAroundValuesInMessage()
+            {
+                // Arrange
+                var actual = new object();
+                var expected = new object();
+                // Pre-Assert
+                // Act
+                Assert.That(() =>
+                    {
+                        Expect(actual).To.Equal(expected);
+                    },
+                    Throws.Exception.InstanceOf<UnmetExpectationException>()
+                        .With.Message.Contains($"Expected {expected} but got {actual}")
+                );
                 // Assert
             }
         }

--- a/src/NExpect/EqualityProviderExtensions.cs
+++ b/src/NExpect/EqualityProviderExtensions.cs
@@ -76,12 +76,12 @@ namespace NExpect
         {
             continuation.AddMatcher(actual =>
             {
-                if (ValuesAreEqual(expected, actual)||
+                if (ValuesAreEqual(expected, actual) ||
                     BothAreNull(expected, actual))
-                    return new MatcherResult(true, $"Did not expect {expected}, but got exactly that");
+                    return new MatcherResult(true, $"Did not expect {Quote(expected)}, but got exactly that");
                 return new MatcherResult(false,
                     FinalMessageFor(
-                        $"Expected {expected} but got {actual}",
+                        $"Expected {Quote(expected)} but got {Quote(actual)}",
                         customMessage
                     ));
             });

--- a/src/NExpect/Implementations/MessageHelpers.cs
+++ b/src/NExpect/Implementations/MessageHelpers.cs
@@ -78,7 +78,7 @@ namespace NExpect.Implementations
         /// <returns>Quoted string, if not null</returns>
         public static string Quote(string str)
         {
-            return str == null ? null : $"\"{str}\"";
+            return str == null ? Null : $"\"{str}\"";
         }
 
         /// <summary>
@@ -90,10 +90,14 @@ namespace NExpect.Implementations
         /// <returns>String representation of object</returns>
         public static string Quote<T>(T o)
         {
-            if (o == null)
-                return null;
-            var asString = o as string;
-            return asString == null ? o.ToString() : Quote(asString);
+            if (typeof(T) == typeof(string))
+            {
+                return Quote(o as string);
+            }
+
+            return o == null
+                ? Null
+                : o.ToString();
         }
 
         /// <summary>


### PR DESCRIPTION
feat: encapsulate string values with quotes in unmet expectation messages
feat: display null values as (null) in unmet expectation messages