### PR TITLE
[PR] The proj files have been updated to enable SourceLink

### DIFF
--- a/src/CoreConsumer/CoreConsumer.csproj
+++ b/src/CoreConsumer/CoreConsumer.csproj
@@ -2,7 +2,15 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <Configurations>Debug;Release;BuildForRelease</Configurations>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="microsoft.net.test.sdk" Version="16.2.0" />
     <PackageReference Include="NExpect" Version="1.0.154" />

--- a/src/NExpect.Matchers.AspNetCore/NExpect.Matchers.AspNetCore.csproj
+++ b/src/NExpect.Matchers.AspNetCore/NExpect.Matchers.AspNetCore.csproj
@@ -7,7 +7,15 @@
     <RootNamespace>NExpect</RootNamespace>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
     <DocumentationFile>NExpect.Matchers.AspNetCore.xml</DocumentationFile>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
   <PropertyGroup>
     <PackageVersion>1.0.174</PackageVersion>
     <DefaultLanguage>en-US</DefaultLanguage>

--- a/src/NExpect.Matchers.NSubstitute/NExpect.Matchers.NSubstitute.csproj
+++ b/src/NExpect.Matchers.NSubstitute/NExpect.Matchers.NSubstitute.csproj
@@ -7,7 +7,15 @@
     <TargetFrameworks>netstandard2.0;net452</TargetFrameworks>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
     <Configurations>Debug;Release;BuildForRelease</Configurations>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
   <PropertyGroup>
     <PackageVersion>1.0.174</PackageVersion>
     <Authors>Davyd McColl</Authors>

--- a/src/NExpect/NExpect.csproj
+++ b/src/NExpect/NExpect.csproj
@@ -6,7 +6,15 @@
     <Configurations>Debug;Release;BuildForRelease</Configurations>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
   <PropertyGroup>
     <PackageVersion>1.0.174</PackageVersion>
     <DefaultLanguage>en-US</DefaultLanguage>


### PR DESCRIPTION
CSProj files have been updated to enable SourceLink in your nuget
---

*[This pull request was created with an automated workflow]*

I noticed that your repository and Nuget package are important for our .NET community, but you still haven't enabled SourceLink.

**We have to take 2 steps:**
1) Please approve this pull request and make .NET a better place for .NET developers and their debugging.
2) **Then just upload the .snupkg file** to https://www.nuget.org/ (now you can find the snupkg file along with the .nuget file)

You can find more information about SourceLine at the following links  
https://github.com/dotnet/sourcelink
https://www.hanselman.com/blog/ExploringNETCoresSourceLinkSteppingIntoTheSourceCodeOfNuGetPackagesYouDontOwn.aspx

If you are interesting about this automated workflow and how it works  
https://github.com/JTOne123/GitHubMassUpdater

*If you notice any flaws, please comment and I will try to make fixes manually*
